### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,12 +3,14 @@ import {BufferFile, NullFile, StreamFile} from 'vinyl';
 export interface Options {
 	/**
 	Override the `base` of the Vinyl file.
+
 	@default process.cwd()
 	*/
 	base?: string;
 
 	/**
 	Override the `cwd` (current working directory) of the Vinyl file.
+
 	@default process.cwd()
 	*/
 	cwd?: string;
@@ -17,12 +19,14 @@ export interface Options {
 	Setting this to `false` will return `file.contents` as a stream. This is useful when working with large files.
 
 	__Note:__ Plugins might not implement support for streams.
+
 	@default true
 	*/
 	buffer?: boolean;
 
 	/**
 	Setting this to `false` will return `file.contents` as `null` and not read the file at all.
+
 	@default true
 	*/
 	read?: boolean;
@@ -30,8 +34,7 @@ export interface Options {
 
 /**
 Create a Vinyl file asynchronously and return it.
-@param path
-@param options
+@param path - Path of file to create vinyl file of.
 @example
 ```
 import {vinylFileSync} from 'vinyl-file';
@@ -51,8 +54,7 @@ export function vinylFileSync(path: string, options?: Options): BufferFile;
 
 /**
 Create a Vinyl file synchronously and return it.
-@param path
-@param options
+@param path - Path of file to create vinyl file of.
 @example
 ```
 import {vinylFile} from 'vinyl-file';

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ export interface Options {
 }
 
 /**
-Create a Vinyl file synchronously and return it.
+Create a Vinyl file asynchronously and return it.
 
 @param path - The path to the file to create a Vinyl file of.
 
@@ -55,7 +55,7 @@ export function vinylFile(path: string, options: Options & {buffer: false}): Pro
 export function vinylFile(path: string, options?: Options): Promise<BufferFile>;
 
 /**
-Create a Vinyl file and return it.
+Create a Vinyl file synchronously and return it.
 
 @param path - The path to the file to create a Vinyl file of.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,28 +33,10 @@ export interface Options {
 }
 
 /**
-Create a Vinyl file asynchronously and return it.
-@param path - Path of file to create vinyl file of.
-@example
-```
-import {vinylFileSync} from 'vinyl-file';
-
-const file = vinylFileSync('index.js');
-
-console.log(file.path);
-//=> '/Users/sindresorhus/dev/vinyl-file/index.js'
-
-console.log(file.cwd);
-//=> '/Users/sindresorhus/dev/vinyl-file'
-```
-*/
-export function vinylFileSync(path: string, options: Options & {read: false}): NullFile;
-export function vinylFileSync(path: string, options: Options & {buffer: false}): StreamFile;
-export function vinylFileSync(path: string, options?: Options): BufferFile;
-
-/**
 Create a Vinyl file synchronously and return it.
-@param path - Path of file to create vinyl file of.
+
+@param path - The path to the file to create a Vinyl file of.
+
 @example
 ```
 import {vinylFile} from 'vinyl-file';
@@ -71,3 +53,25 @@ console.log(file.cwd);
 export function vinylFile(path: string, options: Options & {read: false}): Promise<NullFile>;
 export function vinylFile(path: string, options: Options & {buffer: false}): Promise<StreamFile>;
 export function vinylFile(path: string, options?: Options): Promise<BufferFile>;
+
+/**
+Create a Vinyl file and return it.
+
+@param path - The path to the file to create a Vinyl file of.
+
+@example
+```
+import {vinylFileSync} from 'vinyl-file';
+
+const file = vinylFileSync('index.js');
+
+console.log(file.path);
+//=> '/Users/sindresorhus/dev/vinyl-file/index.js'
+
+console.log(file.cwd);
+//=> '/Users/sindresorhus/dev/vinyl-file'
+```
+*/
+export function vinylFileSync(path: string, options: Options & {read: false}): NullFile;
+export function vinylFileSync(path: string, options: Options & {buffer: false}): StreamFile;
+export function vinylFileSync(path: string, options?: Options): BufferFile;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,71 @@
+import {BufferFile, NullFile, StreamFile} from 'vinyl';
+
+export interface Options {
+	/**
+	Override the `base` of the Vinyl file.
+	@default process.cwd()
+	*/
+	base?: string;
+
+	/**
+	Override the `cwd` (current working directory) of the Vinyl file.
+	@default process.cwd()
+	*/
+	cwd?: string;
+
+	/**
+	Setting this to `false` will return `file.contents` as a stream. This is useful when working with large files.
+
+	__Note:__ Plugins might not implement support for streams.
+	@default true
+	*/
+	buffer?: boolean;
+
+	/**
+	Setting this to `false` will return `file.contents` as `null` and not read the file at all.
+	@default true
+	*/
+	read?: boolean;
+}
+
+/**
+Create a Vinyl file asynchronously and return it.
+@param path
+@param options
+@example
+```
+import {vinylFileSync} from 'vinyl-file';
+
+const file = vinylFileSync('index.js');
+
+console.log(file.path);
+//=> '/Users/sindresorhus/dev/vinyl-file/index.js'
+
+console.log(file.cwd);
+//=> '/Users/sindresorhus/dev/vinyl-file'
+```
+*/
+export function vinylFileSync(path: string, options: Options & {read: false}): NullFile;
+export function vinylFileSync(path: string, options: Options & {buffer: false}): StreamFile;
+export function vinylFileSync(path: string, options?: Options): BufferFile;
+
+/**
+Create a Vinyl file synchronously and return it.
+@param path
+@param options
+@example
+```
+import {vinylFile} from 'vinyl-file';
+
+const file = await vinylFile('index.js');
+
+console.log(file.path);
+//=> '/Users/sindresorhus/dev/vinyl-file/index.js'
+
+console.log(file.cwd);
+//=> '/Users/sindresorhus/dev/vinyl-file'
+```
+*/
+export function vinylFile(path: string, options: Options & {read: false}): Promise<NullFile>;
+export function vinylFile(path: string, options: Options & {buffer: false}): Promise<StreamFile>;
+export function vinylFile(path: string, options?: Options): Promise<BufferFile>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,31 @@
+import {expectType} from 'tsd';
+import {BufferFile, NullFile, StreamFile} from 'vinyl';
+import {vinylFile, vinylFileSync} from './index.js';
+
+expectType<Promise<NullFile>>(vinylFile('./', {read: false}));
+expectType<Promise<NullFile>>(vinylFile('./', {read: false, buffer: true}));
+expectType<Promise<NullFile>>(vinylFile('./', {read: false, buffer: false}));
+
+expectType<Promise<StreamFile>>(vinylFile('./', {buffer: false}));
+expectType<Promise<StreamFile>>(vinylFile('./', {read: true, buffer: false}));
+
+expectType<Promise<BufferFile>>(vinylFile('./', {base: undefined, cwd: undefined, buffer: true, read: true}));
+expectType<Promise<BufferFile>>(vinylFile('./', {buffer: true}));
+expectType<Promise<BufferFile>>(vinylFile('./', {buffer: undefined, read: true}));
+expectType<Promise<BufferFile>>(vinylFile('./', {read: undefined}));
+expectType<Promise<BufferFile>>(vinylFile('./', {}));
+expectType<Promise<BufferFile>>(vinylFile('./'));
+
+expectType<NullFile>(vinylFileSync('./', {read: false}));
+expectType<NullFile>(vinylFileSync('./', {read: false, buffer: true}));
+expectType<NullFile>(vinylFileSync('./', {read: false, buffer: false}));
+
+expectType<StreamFile>(vinylFileSync('./', {buffer: false}));
+expectType<StreamFile>(vinylFileSync('./', {read: true, buffer: false}));
+
+expectType<BufferFile>(vinylFileSync('./', {base: undefined, cwd: undefined, buffer: true, read: true}));
+expectType<BufferFile>(vinylFileSync('./', {buffer: true}));
+expectType<BufferFile>(vinylFileSync('./', {buffer: undefined, read: true}));
+expectType<BufferFile>(vinylFileSync('./', {read: undefined}));
+expectType<BufferFile>(vinylFileSync('./', {}));
+expectType<BufferFile>(vinylFileSync('./'));

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
 		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"vinyl",
@@ -32,6 +33,7 @@
 		"gulpfriendly"
 	],
 	"dependencies": {
+		"@types/vinyl": "^2.0.6",
 		"strip-bom-buf": "^3.0.0",
 		"strip-bom-stream": "^5.0.0",
 		"vinyl": "^2.2.1"
@@ -39,6 +41,7 @@
 	"devDependencies": {
 		"ava": "^3.15.0",
 		"is-stream": "^3.0.0",
+		"tsd": "^0.19.1",
 		"xo": "^0.44.0"
 	}
 }


### PR DESCRIPTION
Adds TypeScript type definitions for the package.

Existing types on DefinitelyTyped (for v3) return generic Vinyl `File` instances.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8feddddbbb2915816ac5787f50b65d267e9e40cf/types/vinyl-file/index.d.ts#L78-L79

This is inconsistent with upstream types, which narrow based on provided options.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/vinyl/index.d.ts#L55-L60

Since narrowing is more correct (and can eliminate redundant checks) I've applied it here.
There is however a problem with the current implementation, it relies on `strictNullChecks`. The following cases fail without the flag enabled.

```ts
expectType<Promise<BufferFile>>(vinylFile('./', {buffer: undefined, read: true})); // returns Promise<StreamFile>
expectType<Promise<BufferFile>>(vinylFile('./', {read: undefined})); // returns Promise<NullFile>
expectType<BufferFile>(vinylFileSync('./', {buffer: undefined, read: true})); // returns StreamFile
expectType<BufferFile>(vinylFileSync('./', {read: undefined})); // returns NullFile
```

`tsd` doesn't report this as a problem, presumably due to it operating under strict mode.

### TODO

- [x] ~Fix incorrect return type when `"strictNullChecks": false`~
   This is also a problem DefinitelyTyped has to deal with and `strictNullChecks` is enabled by default over there (see https://github.com/DefinitelyTyped/DefinitelyTyped#tsconfigjson). I'm happy to consider this not working without `strictNullChecks` as an unsupported scenario, if this is a dealbreaker happy to change back to a merge generic return type.

Resolves #9 